### PR TITLE
Updated BLEShieldSS to include setting the pinModes

### DIFF
--- a/arduino/BLEShieldSS/BLEShieldSS.ino
+++ b/arduino/BLEShieldSS/BLEShieldSS.ino
@@ -31,6 +31,10 @@ long interval = 1000;
 
 void setup()  
 {
+  // Setup the RX/TX pins so the SoftwareSerial will send and receive
+  pinMode(2,INPUT);
+  pinMode(3,OUTPUT);
+
   // set the data rate for the SoftwareSerial port
   bleShield.begin(19200);
   Serial.begin(19200);


### PR DESCRIPTION
Ran into this issue with my 1.0.0 BLE Shield running on an Arduino UNO. Arduino could receive data but couldn't send back. Setting the pinModes fixed it, which makes sense because pin 3 is used to transmit from Arduino, so unless its set to OUTPUT it will not send data correctly.